### PR TITLE
Tweak: Deletion of the Funky Emoji

### DIFF
--- a/microsoft_proxies.py
+++ b/microsoft_proxies.py
@@ -88,7 +88,7 @@ def update_database(db_path="microsoft_services.db"):
             c.execute("INSERT INTO tags VALUES (?, ?)", (tag, prefix))
 
     prefixes = {row[0] for row in c.execute("SELECT DISTINCT prefix FROM tags")}
-    print(f"🔍 Performing parallel ASN lookups for {len(prefixes)} prefixes...")
+    print(f"Performing parallel ASN lookups for {len(prefixes)} prefixes...")
 
     def lookup_asn(prefix):
         ip = prefix.split('/')[0]


### PR DESCRIPTION
Tweak: I deleted the emoji that was present in the script when the script started the parallel search.

I tried to play around with that but I felt that it looked too 'childish' in the release of the script. I accidently forgot to remove this one.

The emojis surrounding the 'Trusted' and the 'Untrusted' state remain to give the user a quick and clear answer.